### PR TITLE
correción modelo usuario, cargue de tipo usuario.

### DIFF
--- a/api/src/controllers/ciudades/postCitiesController.js
+++ b/api/src/controllers/ciudades/postCitiesController.js
@@ -10,7 +10,6 @@ const loadCities = async () => {
     const ciudades = JSON.parse(ciudadesJSON);
     let mapCiudades = ciudades.map((prop) => ({ id_ciudad: prop.id,
         nombre_ciudad: prop.nombre }));
-    console.log(mapCiudades);
     
     await Ciudad.bulkCreate(mapCiudades, { validate: true });
     

--- a/api/src/controllers/usuarios/postUsuarioController.js
+++ b/api/src/controllers/usuarios/postUsuarioController.js
@@ -1,5 +1,28 @@
 const bcrypt = require("bcrypt");
-const { Usuario } = require("../../db");
+const { Usuario, Tipo_usuario } = require("../../db");
+
+const guardarTipoUsuario = async () =>{
+  try {
+    let tipoUsuario = [
+      {nombre_tipo_usuario: "Cliente"},
+      {nombre_tipo_usuario: "Administrador"}
+    ]
+    let mapTipoUsuario = tipoUsuario.map((prop) => ({nombre_tipo_usuario: prop.nombre_tipo_usuario}));
+    await Tipo_usuario.bulkCreate(mapTipoUsuario);
+    console.log('se guardaron los tipos de usuarios correctamente');
+    
+  } catch (error) {
+    
+      console.error('Error al cargar los tipos de Usuarios', error);
+  }
+
+}
+
+const verifyDb = async () =>{
+  const aux = await Tipo_usuario.count();
+  if(aux < 1) await guardarTipoUsuario() ;
+}
+
 
 const createUsuario = async (
   id_tipo_usuario,
@@ -16,6 +39,8 @@ const createUsuario = async (
   contraseña,
   imagen
 ) => {
+
+  verifyDb();
   // Generar un salt para el hash
   const salt = await bcrypt.genSalt(10);
 

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -55,10 +55,31 @@ const {
 // Aca vendrian las relaciones
 // Product.hasMany(Reviews);
 
-Tipo_usuario.hasMany(Usuario);
+// Tipo_usuario.hasMany(Usuario);
+
+Tipo_usuario.hasMany(Usuario, {
+  foreignKey: 'id_tipo_usuario',
+  onDelete: 'CASCADE',
+});
+
+Usuario.belongsTo(Tipo_usuario, {
+  foreignKey: 'id_tipo_usuario',
+});
 
 Producto.hasMany(Motivo_calificacion);
-Ciudad.hasMany(Usuario);
+// Ciudad.hasMany(Usuario);
+
+Ciudad.hasMany(Usuario, {
+  foreignKey: 'id_ciudad',
+  onDelete: 'CASCADE',
+});
+
+Usuario.belongsTo(Ciudad, {
+  foreignKey: 'id_ciudad',
+});
+
+
+
 Ciudad.hasMany(Comercio);
 Usuario.hasMany(Venta);
 Categoria_comercio.hasMany(Comercio);

--- a/api/src/models/Ciudad.js
+++ b/api/src/models/Ciudad.js
@@ -3,7 +3,7 @@ const { DataTypes } = require('sequelize');
 // Luego le injectamos la conexion a sequelize.
 module.exports = (sequelize) => {
   // defino el modelo
-  sequelize.define('ciudad', {
+  sequelize.define('Ciudad', {
     id_ciudad: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/api/src/models/usuario.js
+++ b/api/src/models/usuario.js
@@ -2,13 +2,13 @@ const { DataTypes } = require('sequelize');
 
 module.exports = (sequelize) => {
 sequelize.define('Usuario', {
-    id_tipo_usuario: {
-      type: DataTypes.INTEGER,
-      references: {
-        model: 'Tipo_usuario',
-        key: 'id_tipo_usuario',
-      },
-    },
+    // id_tipo_usuario: {
+    //   type: DataTypes.INTEGER,
+    //   references: {
+    //     model: 'Tipo_usuario',
+    //     key: 'id_tipo_usuario',
+    //   },
+    // },
     id_usuario: {
       type: DataTypes.INTEGER,
       allowNull: false, 
@@ -37,13 +37,13 @@ sequelize.define('Usuario', {
       type: DataTypes.BIGINT,
       allowNull: false,
     },
-    id_ciudad:{
-      type: DataTypes.INTEGER,
-      references:{
-        model: "Ciudad",
-        key: "id_ciudad"
-      }
-    },
+    // id_ciudad:{
+    //   type: DataTypes.INTEGER,
+    //   references:{
+    //     model: "Ciudad",
+    //     key: "id_ciudad"
+    //   }
+    // },
     estado:{
       type: DataTypes.BOOLEAN
     },


### PR DESCRIPTION
se corrigió modelo Usuario, se quitaron los campos id_ciudad y id_tipo_usuario, se modificó la relación de estas tablas en el archivo db.js para que sequalize cree estos dos campos en la tabla Usuario automáticamente cuando crea la relación entre ellas y cuando se hace un post de usuario sequalize crea estos campos en la tabla y guarda los datos el usuario creado en esa tabla,
se realizó el cargue en la tabla Tipo_usuario, se dejó para que antes de hacer el post de usuario se haga el cargue primero de la tabla Tipo_usuario, y cuando se envía el post en el lado del front deben enviar en el campo id_usuario el 1 para el tipo cliente y el 2 para el tipo administrador.